### PR TITLE
fix: Drop the reasoning parser arg for vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ vllm serve nvidia/Cosmos-Reason2-2B \
   --allowed-local-media-path "$(pwd)" \
   --max-model-len 16384 \
   --media-io-kwargs '{"video": {"num_frames": -1}}' \
-  --reasoning-parser qwen3 \
   --port 8000
 ```
 
@@ -193,7 +192,6 @@ Optional arguments:
 
 * `--max-model-len 16384`: Maximum model length to avoid OOM. Recommended range: 8192 - 16384.
 * `--media-io-kwargs '{"video": {"num_frames": -1}}'`: Allow overriding FPS per sample.
-* `--reasoning-parser qwen3`: Parse reasoning trace.
 * `--port 8000`: Server port. Change if you encounter `Address already in use` errors.
 
 > [!NOTE]


### PR DESCRIPTION
With this enabled all model output is detected as thinking:

```python
import os
import base64
from openai import OpenAI

client = OpenAI(api_key='EMPTY', base_url='http://localhost:8001/v1')

def encode_image(image_path):
  with open(image_path, 'rb') as f:
      return base64.b64encode(f.read()).decode('utf-8')

base64_image = encode_image('path/to/image')

resp = client.chat.completions.create(
  model='Cosmos-Reason2-8B',
  messages=[{'role': 'user', 'content': [
      {'type': 'text', 'text': \"What's in this image?\"},
      {'type': 'image_url', 'image_url': {'url': f'data:image/jpeg;base64,{base64_image}', 'detail': 'auto'}},
  ]}],
)
print(resp)
```

Which gives the following result:
```
ChatCompletion(
    id='...',
    choices=[
        Choice(
            finish_reason='stop',
            index=0,
            logprobs=None,
            message=ChatCompletionMessage(
                content=None,
                refusal=None,
                role='assistant',
                annotations=None,
                audio=None,
                function_call=None,
                tool_calls=[],
                reasoning='...' # <-- all the prompt response is in here
            ),
            stop_reason=None,
            token_ids=None
        )
    ],
    created=1780339261,
    model='Cosmos-Reason2-8B',
    object='chat.completion',
    service_tier=None,
    system_fingerprint=None,
    usage=CompletionUsage(
        completion_tokens=204,
        prompt_tokens=1491,
        total_tokens=1695,
        completion_tokens_details=None,
        prompt_tokens_details=None
    ),
    prompt_logprobs=None,
    prompt_token_ids=None,
    kv_transfer_params=None
)
```

This was the problematic vLLM config that worked with `--reasoning-parser qwen3` dropped:
```
vllm serve nvidia/Cosmos-Reason2-8B \
    --allowed-local-media-path . \
    --max-model-len 16384 \
    --media-io-kwargs '{"video": {"num_frames": -1}}' \
    --reasoning-parser qwen3 \
    --port 8001
```

Execution environment was vLLM (via `nvcr.io/nvidia/vllm:26.04-py3`) on a NVIDIA DGX Spark:
```
NVIDIA Release 26.04 (build 299333414)
vLLM Version 0.19.0+6bc3197f
```
